### PR TITLE
refactor(admin): move team pick-rank reorder onto Team

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -20,41 +20,11 @@ class Admin::TeamsController < Admin::BaseController
   end
 
   def move_up
-    if @team.default_pick_rank.nil?
-      return redirect_to admin_teams_path(list_params), alert: "Cannot move a team without a pick rank."
-    end
-
-    swap_with = Team.where(sport_id: @team.sport_id)
-      .where.not(id: @team.id)
-      .where(default_pick_rank: ...@team.default_pick_rank)
-      .order(default_pick_rank: :desc)
-      .first
-
-    if swap_with
-      swap_ranks(@team, swap_with)
-      redirect_to admin_teams_path(list_params), notice: "Moved #{@team.name} up."
-    else
-      redirect_to admin_teams_path(list_params), alert: "#{@team.name} is already at the top."
-    end
+    move(:up, edge: "top")
   end
 
   def move_down
-    if @team.default_pick_rank.nil?
-      return redirect_to admin_teams_path(list_params), alert: "Cannot move a team without a pick rank."
-    end
-
-    swap_with = Team.where(sport_id: @team.sport_id)
-      .where.not(id: @team.id)
-      .where(default_pick_rank: (@team.default_pick_rank + 1)..)
-      .order(default_pick_rank: :asc)
-      .first
-
-    if swap_with
-      swap_ranks(@team, swap_with)
-      redirect_to admin_teams_path(list_params), notice: "Moved #{@team.name} down."
-    else
-      redirect_to admin_teams_path(list_params), alert: "#{@team.name} is already at the bottom."
-    end
+    move(:down, edge: "bottom")
   end
 
   def update
@@ -93,13 +63,19 @@ class Admin::TeamsController < Admin::BaseController
     @team = Team.find(params[:id])
   end
 
-  def swap_ranks(a, b)
-    Team.transaction do
-      a_rank = a.default_pick_rank
-      b_rank = b.default_pick_rank
-      a.update!(default_pick_rank: nil)
-      b.update!(default_pick_rank: a_rank)
-      a.update!(default_pick_rank: b_rank)
+  def move(direction, edge:)
+    if @team.default_pick_rank.nil?
+      return redirect_to admin_teams_path(list_params),
+        alert: "Cannot move a team without a pick rank."
+    end
+
+    moved = (direction == :up) ? @team.move_pick_rank_up! : @team.move_pick_rank_down!
+    if moved
+      redirect_to admin_teams_path(list_params),
+        notice: "Moved #{@team.name} #{direction}."
+    else
+      redirect_to admin_teams_path(list_params),
+        alert: "#{@team.name} is already at the #{edge}."
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -14,4 +14,47 @@ class Team < ApplicationRecord
     uniqueness: {scope: :sport_id, case_sensitive: false},
     format: {with: SLUG_FORMAT}
   validates :external_id, uniqueness: {scope: :sport_id, allow_nil: true}
+
+  # The Positional concern can't be used here: (sport_id, default_pick_rank)
+  # is a unique *index*, not a deferrable unique *constraint*, so we can't
+  # swap with `SET CONSTRAINTS ALL DEFERRED`. Park one row at NULL (allowed
+  # by the index's nullable column) while the other moves, then restore.
+  def swap_default_pick_rank_with(other)
+    self.class.transaction do
+      a_rank = default_pick_rank
+      b_rank = other.default_pick_rank
+      update!(default_pick_rank: nil)
+      other.update!(default_pick_rank: a_rank)
+      update!(default_pick_rank: b_rank)
+    end
+    true
+  end
+
+  def move_pick_rank_up!
+    swap_pick_rank_with_neighbour(:above)
+  end
+
+  def move_pick_rank_down!
+    swap_pick_rank_with_neighbour(:below)
+  end
+
+  private
+
+  def swap_pick_rank_with_neighbour(direction)
+    return false if default_pick_rank.nil?
+    neighbour = pick_rank_neighbour(direction)
+    return false unless neighbour
+    swap_default_pick_rank_with(neighbour)
+  end
+
+  def pick_rank_neighbour(direction)
+    scope = self.class.where(sport_id: sport_id).where.not(id: id)
+    if direction == :above
+      scope.where(default_pick_rank: ...default_pick_rank)
+        .order(default_pick_rank: :desc).first
+    else
+      scope.where(default_pick_rank: (default_pick_rank + 1)..)
+        .order(default_pick_rank: :asc).first
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Tier 2.2 of the architecture cleanup. Mirrors the Participant / UserTeamRanking cleanup from #45 but keeps `Team` out of the `Positional` concern.

The reason: `(sport_id, default_pick_rank)` is a unique *index*, not a `DEFERRABLE` unique *constraint*. Indexes can't be deferred, so the swap can't use `SET CONSTRAINTS ALL DEFERRED` the way the other two do. This PR takes option B from the refactor plan — keep the nil-trick idiom (park one row at NULL, move the other, restore), just move it from the controller onto the model. No schema change.

### New on `Team`

\`\`\`ruby
team.move_pick_rank_up!      # boolean
team.move_pick_rank_down!    # boolean
team.swap_default_pick_rank_with(other)
\`\`\`

### Controller after this

`Admin::TeamsController` drops the inline neighbor query and the local `swap_ranks` private method. Both move actions collapse into the same `move(direction, edge:)` shape used by `ParticipantsController` and `RankingsController` after PR #45 — keeps the three sites consistent at a glance.

The "Cannot move a team without a pick rank." precondition stays in the controller. The model returns false for both nil-rank and no-neighbour; distinguishing those failure modes controller-side keeps the messaging crisp without growing the model API.

Net: 2 files, +58 / -39.

## Test plan

- [x] Full RSpec suite green (310 examples, 0 failures)
- [x] StandardRB clean on touched files
- [x] Manual: visit `/admin/teams`, reorder two adjacent ranked teams — confirm move
- [ ] Manual: try to move a team with no pick rank — confirm the precondition flash still fires
- [ ] Manual: try to move the top-ranked team up (and bottom team down) — confirm the "already at the top/bottom" flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)