### PR TITLE
refactor(models): LeagueSeason predicates; tell-don't-ask draft state

### DIFF
--- a/app/controllers/draft_picks_controller.rb
+++ b/app/controllers/draft_picks_controller.rb
@@ -24,23 +24,12 @@ class DraftPicksController < ApplicationController
     participant = current_participant_for(@league)
     return unauthorized!("Claim a seat to draft.") unless participant
 
-    case @league_season.draft_mode
-    when "manual"
+    if @league_season.manual_mode?
       unauthorized!("Only the league owner can record picks in a manual draft.") unless participant.is_owner?
-    when "live"
-      on_clock = clock_participant
+    elsif @league_season.live_mode?
+      on_clock = @league_season.current_picker
       unauthorized!("It's not your turn yet.") unless on_clock && participant.id == on_clock.id
     end
-  end
-
-  def clock_participant
-    return nil if @league_season.current_pick_number > @league_season.total_picks
-    pos = Drafts::Order.position_for(
-      pick_number: @league_season.current_pick_number,
-      size: @league_season.size,
-      style: @league_season.draft_order_style
-    )
-    @league_season.participants.find_by(draft_position: pos)
   end
 
   def unauthorized!(message)

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -34,7 +34,7 @@ class DraftsController < ApplicationController
   end
 
   def update
-    if @league_season.draft_picks.any?
+    if @league_season.started?
       redirect_to league_path(@league), alert: "Draft has started - settings are locked."
       return
     end
@@ -46,9 +46,7 @@ class DraftsController < ApplicationController
         zone: params.dig(:league_season, :time_zone)
       )
     end
-    @league_season.assign_attributes(attrs)
-    normalize_draft_mode_switch(@league_season)
-    @league_season.save!
+    @league_season.update!(attrs)
     redirect_to league_path(@league), notice: "Draft settings updated."
   rescue ActiveRecord::RecordInvalid
     render Views::Drafts::Edit.new(league: @league, league_season: @league_season),
@@ -60,14 +58,6 @@ class DraftsController < ApplicationController
   def league_season_params
     params.require(:league_season).permit(:draft_mode, :draft_order_style,
       :draft_scheduled_at, :pick_clock_seconds)
-  end
-
-  def normalize_draft_mode_switch(league_season)
-    case league_season.draft_mode
-    when "manual"
-      league_season.pick_clock_seconds = nil
-      league_season.draft_scheduled_at = nil
-    end
   end
 
   def build_directory_query

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -38,7 +38,7 @@ class ParticipantsController < ApplicationController
   end
 
   def draft_started?
-    @league_season.draft_picks.any?
+    @league_season.started?
   end
 
   def redirect_locked

--- a/app/jobs/drafts/pick_clock_job.rb
+++ b/app/jobs/drafts/pick_clock_job.rb
@@ -13,7 +13,7 @@ module Drafts
 
     def perform(league_season_id, expected_pick_number)
       ls = LeagueSeason.find(league_season_id)
-      return unless ls.draft_mode == "live"
+      return unless ls.live_mode?
       return unless %w[draft_pending drafting].include?(ls.status)
       return unless ls.current_pick_number == expected_pick_number
 

--- a/app/lib/drafts/start_if_ready.rb
+++ b/app/lib/drafts/start_if_ready.rb
@@ -32,10 +32,8 @@ module Drafts
     private
 
     def ready?
-      manual? ? owner_joined? : seats_filled?
+      @league_season.manual_mode? ? owner_joined? : seats_filled?
     end
-
-    def manual? = @league_season.draft_mode == "manual"
 
     def owner_joined?
       @league_season.participants.where(is_owner: true).where.not(joined_at: nil).exists?
@@ -47,7 +45,7 @@ module Drafts
     end
 
     def scheduled_in_future?
-      !manual? &&
+      @league_season.live_mode? &&
         @league_season.draft_scheduled_at.present? &&
         @league_season.draft_scheduled_at > Time.current
     end
@@ -59,7 +57,7 @@ module Drafts
     end
 
     def schedule_first_clock
-      return unless @league_season.draft_mode == "live" && @league_season.pick_clock_seconds.present?
+      return unless @league_season.live_mode? && @league_season.pick_clock_seconds.present?
       Drafts::PickClockJob
         .set(wait: @league_season.pick_clock_seconds.seconds)
         .perform_later(@league_season.id, @league_season.current_pick_number)

--- a/app/lib/drafts/submit_pick.rb
+++ b/app/lib/drafts/submit_pick.rb
@@ -56,7 +56,7 @@ module Drafts
     private
 
     def schedule_next_clock(ls)
-      return unless ls.draft_mode == "live"
+      return unless ls.live_mode?
       return unless ls.pick_clock_seconds.present?
       return unless ls.status == "drafting"
 

--- a/app/lib/leagues/create.rb
+++ b/app/lib/leagues/create.rb
@@ -54,7 +54,8 @@ module Leagues
 
     # Live drafts need a clock for the auto-pick job to fire on a schedule;
     # default to LeagueSeason::DEFAULT_PICK_CLOCK_SECONDS when the caller
-    # doesn't specify one. Manual drafts stay clockless.
+    # doesn't specify one. Manual drafts stay clockless — the LeagueSeason
+    # `before_validation` also nils any stray clock value defensively.
     def resolve_pick_clock(value)
       return nil unless @draft_mode == "live"
       value.presence&.to_i || LeagueSeason::DEFAULT_PICK_CLOCK_SECONDS

--- a/app/models/league_season.rb
+++ b/app/models/league_season.rb
@@ -15,6 +15,7 @@ class LeagueSeason < ApplicationRecord
   broadcasts_refreshes_to ->(ls) { ls.league }
 
   before_validation :assign_invite_code, on: :create
+  before_validation :normalize_for_draft_mode
 
   validates :season_id, uniqueness: {scope: :league_id}
   validates :size, numericality: {only_integer: true, greater_than_or_equal_to: 2, less_than_or_equal_to: 8}
@@ -45,6 +46,27 @@ class LeagueSeason < ApplicationRecord
     %w[in_season completed].include?(status)
   end
 
+  def started?
+    draft_picks.any?
+  end
+
+  def manual_mode? = draft_mode == "manual"
+
+  def live_mode? = draft_mode == "live"
+
+  # The participant whose turn it is, or nil if the draft is complete.
+  # Pure function of `current_pick_number`, `size`, and `draft_order_style`;
+  # encapsulates the Drafts::Order lookup so callers don't repeat it.
+  def current_picker
+    return nil if current_pick_number > total_picks
+    pos = Drafts::Order.position_for(
+      pick_number: current_pick_number,
+      size: size,
+      style: draft_order_style
+    )
+    participants.find_by(draft_position: pos)
+  end
+
   def picks_per_participant
     season.season_teams.count / size
   end
@@ -57,5 +79,14 @@ class LeagueSeason < ApplicationRecord
 
   def assign_invite_code
     self.invite_code ||= self.class.generate_unique_invite_code
+  end
+
+  # Manual drafts have no clock and no scheduled start. Clearing on save
+  # keeps stale "live"-mode values from sneaking through if the owner
+  # switches the draft from live to manual.
+  def normalize_for_draft_mode
+    return unless manual_mode?
+    self.pick_clock_seconds = nil
+    self.draft_scheduled_at = nil
   end
 end


### PR DESCRIPTION
## Summary

Tier 3 of the architecture cleanup. Moves draft-state introspection off the controllers and onto `LeagueSeason`. The repeated pattern was:

\`\`\`ruby
@league_season.draft_picks.any?
@league_season.draft_mode == "manual"
@league_season.status == "drafting"
\`\`\`

Controllers (and a couple of service objects) were poking model state directly. The model now exposes the domain vocabulary.

### New on `LeagueSeason`

\`\`\`ruby
started?       # draft_picks.any?
manual_mode?   # draft_mode == "manual"
live_mode?     # draft_mode == "live"
current_picker # the Participant on the clock, or nil if draft is complete
\`\`\`

`current_picker` wraps the `Drafts::Order` lookup that `DraftPicksController#clock_participant` used to do — `pick_number` + `size` + `style` → `Participant` resolution behind a single call.

### `normalize_for_draft_mode` becomes a model invariant

`DraftsController#update` had a `normalize_draft_mode_switch` step that cleared `pick_clock_seconds` and `draft_scheduled_at` whenever the mode flipped to manual. That's a domain invariant — manual drafts have no clock and no scheduled start. Moved to a `before_validation` callback on `LeagueSeason`, so clearing happens whether the update comes through this controller, an admin tool, or anywhere else.

The controller's `update` action collapses from `assign_attributes` + normalize + `save!` into a single `update!(attrs)`.

### Adopters

Controllers: `ParticipantsController`, `DraftsController`, `DraftPicksController`.

Services & jobs cleaned up so the vocabulary is consistent across the domain layer:
- `Drafts::StartIfReady` (loses its local `manual?` predicate)
- `Drafts::SubmitPick`
- `Drafts::PickClockJob`

Views deliberately left alone — the Phlex audit found them idiomatic, and changing string comparisons to predicate calls there would balloon the diff for no behavior benefit. They can adopt the predicates organically.

Net: +44 / -35; controllers shrink, model carries 31 new LOC of domain predicates.

## Test plan

- [x] Full RSpec suite green (310 examples, 0 failures)
- [x] StandardRB clean on touched files
- [x] Manual: create a live league, edit settings before any picks — confirm save works
- [ ] Manual: create a league, make a pick, then try to edit draft settings — confirm "Draft has started" flash fires
- [x] Manual: live draft, confirm `current_picker` resolution still puts the right participant on the clock
- [ ] Manual: edit a live league, switch mode to manual, save — confirm pick_clock_seconds and draft_scheduled_at get cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)