### PR TITLE
refactor(invites): extract verification + seat-claim services

### DIFF
--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -46,18 +46,11 @@ class LeaguesController < ApplicationController
 
   def show
     @league_season = @league.current_league_season
+
     if params[:invite].present?
-      if @league_season&.verify_invite!(params[:invite])
-        mark_invite_verified(@league_season)
-        claimed = auto_claim_lone_seat(@league_season)
-        if claimed
-          redirect_to league_path(@league), notice: "Welcome, #{claimed.display_name}." and return
-        else
-          redirect_to league_path(@league) and return
-        end
-      else
-        flash.now[:alert] = "That invite code didn't match."
-      end
+      result = attempt_invite(params[:invite])
+      return redirect_after_claim(result) if result.verified?
+      flash.now[:alert] = "That invite code didn't match."
     end
 
     # Two URLs, two intents: /leagues/:id is the standings/landing page;
@@ -77,7 +70,7 @@ class LeaguesController < ApplicationController
       league: @league,
       league_season: @league_season,
       current_participant: current_participant_for(@league),
-      invite_verified: invite_verified_for?(@league_season),
+      invite_verified: invite_verifications.verified?(@league_season),
       directory_query: build_directory_query
     )
   end
@@ -103,7 +96,7 @@ class LeaguesController < ApplicationController
 
   def claim
     league_season = @league.current_league_season
-    unless invite_verified_for?(league_season)
+    unless invite_verifications.verified?(league_season)
       redirect_to league_path(@league), alert: "Enter the league's invite code to claim a seat."
       return
     end
@@ -114,26 +107,15 @@ class LeaguesController < ApplicationController
       return
     end
 
-    seat.update!(joined_at: Time.current, user: current_user)
-    participant_claims.add(seat.claim_token)
-    Drafts::StartIfReady.call(league_season: league_season)
+    Invites::ClaimSeat.call(seat: seat, user: current_user, participant_claims: participant_claims)
     redirect_to league_path(@league), notice: "Welcome, #{seat.display_name}."
   end
 
   def verify_invite
-    league_season = @league.current_league_season
-    code = params[:code].to_s
-    if league_season&.verify_invite!(code)
-      mark_invite_verified(league_season)
-      claimed = auto_claim_lone_seat(league_season)
-      if claimed
-        redirect_to league_path(@league), notice: "Welcome, #{claimed.display_name}."
-      else
-        redirect_to league_path(@league)
-      end
-    else
-      redirect_to league_path(@league), alert: "That invite code didn't match."
-    end
+    @league_season = @league.current_league_season
+    result = attempt_invite(params[:code])
+    return redirect_after_claim(result) if result.verified?
+    redirect_to league_path(@league), alert: "That invite code didn't match."
   end
 
   private
@@ -221,29 +203,23 @@ class LeaguesController < ApplicationController
     )
   end
 
-  def invite_verified_for?(league_season)
-    return false unless league_season
-    session[:verified_invites].is_a?(Hash) &&
-      session[:verified_invites][league_season.id.to_s] == true
+  def invite_verifications
+    @invite_verifications ||= Invites::Verifications.new(session)
   end
 
-  def mark_invite_verified(league_season)
-    session[:verified_invites] ||= {}
-    session[:verified_invites][league_season.id.to_s] = true
+  def attempt_invite(code)
+    Invites::Claim.call(
+      league_season: @league_season,
+      code: code,
+      user: current_user,
+      current_participant: current_participant_for(@league),
+      participant_claims: participant_claims,
+      verifications: invite_verifications
+    )
   end
 
-  # When a verified invitee lands on a league with exactly one unclaimed seat
-  # and isn't already a participant, skip the "Are you {name}?" picker and
-  # claim it for them. Returns the claimed Participant, or nil if no claim
-  # was performed (already in, multiple open seats, or none).
-  def auto_claim_lone_seat(league_season)
-    return nil if current_participant_for(@league).present?
-    open_seats = league_season.participants.where(joined_at: nil).to_a
-    return nil unless open_seats.size == 1
-    seat = open_seats.first
-    seat.update!(joined_at: Time.current, user: current_user)
-    participant_claims.add(seat.claim_token)
-    Drafts::StartIfReady.call(league_season: league_season)
-    seat
+  def redirect_after_claim(result)
+    notice = result.auto_claimed? ? "Welcome, #{result.claimed_seat.display_name}." : nil
+    redirect_to league_path(@league), notice: notice
   end
 end

--- a/app/lib/invites/claim.rb
+++ b/app/lib/invites/claim.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Invites
+  # Handles an invite-code submission. If the code matches, marks the
+  # session as verified and - when the visitor isn't already a
+  # participant and exactly one seat is open - auto-claims it on their
+  # behalf, skipping the manual "are you {name}?" picker.
+  #
+  # Returns a Result so callers can branch on:
+  #   - verified?      did the code match
+  #   - auto_claimed?  did we silently take the lone open seat
+  class Claim
+    Result = Data.define(:verified, :claimed_seat) do
+      def verified? = verified
+
+      def auto_claimed? = !claimed_seat.nil?
+    end
+
+    NOT_VERIFIED = Result.new(verified: false, claimed_seat: nil).freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(league_season:, code:, user:, current_participant:,
+      participant_claims:, verifications:)
+      @league_season = league_season
+      @code = code
+      @user = user
+      @current_participant = current_participant
+      @participant_claims = participant_claims
+      @verifications = verifications
+    end
+
+    def call
+      return NOT_VERIFIED unless @league_season&.verify_invite!(@code.to_s)
+      @verifications.mark!(@league_season)
+      Result.new(verified: true, claimed_seat: maybe_auto_claim)
+    end
+
+    private
+
+    def maybe_auto_claim
+      return nil if @current_participant
+      open_seats = @league_season.participants.where(joined_at: nil).to_a
+      return nil unless open_seats.size == 1
+      ClaimSeat.call(
+        seat: open_seats.first,
+        user: @user,
+        participant_claims: @participant_claims
+      )
+    end
+  end
+end

--- a/app/lib/invites/claim_seat.rb
+++ b/app/lib/invites/claim_seat.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Invites
+  # Atomically claims a Participant seat for a visitor: stamps joined_at,
+  # records the optional user, adds the seat's claim token to the visitor's
+  # cookie, and kicks the draft if both seats are now filled.
+  #
+  # Shared by the manual seat-picker (#claim action) and the auto-claim
+  # path that fires when a verified invitee lands on a league with one
+  # unclaimed seat.
+  class ClaimSeat
+    def self.call(...) = new(...).call
+
+    def initialize(seat:, user:, participant_claims:)
+      @seat = seat
+      @user = user
+      @participant_claims = participant_claims
+    end
+
+    def call
+      @seat.update!(joined_at: Time.current, user: @user)
+      @participant_claims.add(@seat.claim_token)
+      Drafts::StartIfReady.call(league_season: @seat.league_season)
+      @seat
+    end
+  end
+end

--- a/app/lib/invites/verifications.rb
+++ b/app/lib/invites/verifications.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Invites
+  # Wraps the per-session record of which LeagueSeason invite codes have
+  # been entered correctly in this browser. Verification gates the seat-
+  # claim UI so a visitor who only knows the league URL can't claim a
+  # seat without the code.
+  #
+  # The session value is shaped like `{"42" => true, "43" => true}`. We
+  # defend the read against non-Hash values (a session may pre-date this
+  # key) but use `||=` on the write to match the historical behavior.
+  class Verifications
+    SESSION_KEY = :verified_invites
+
+    def initialize(session)
+      @session = session
+    end
+
+    def verified?(league_season)
+      return false unless league_season
+      store[league_season.id.to_s] == true
+    end
+
+    def mark!(league_season)
+      return unless league_season
+      @session[SESSION_KEY] ||= {}
+      @session[SESSION_KEY][league_season.id.to_s] = true
+    end
+
+    private
+
+    def store
+      raw = @session[SESSION_KEY]
+      raw.is_a?(Hash) ? raw : {}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Tier 4 of the architecture cleanup. Pulls the invite/claim orchestration out of `LeaguesController` and onto three small POROs under `Invites::`.

The starting point: `LeaguesController#show` was doing four jobs inline — verify an invite code, store the verification in the session, conditionally auto-claim the lone seat, and decide whether to redirect to the draft room. Plus a near-identical copy of three of those in `#verify_invite`, and a manual `#claim` action that re-implemented half of the seat-claim primitive. This PR factors that out so each layer owns one job.

### New under `Invites::`

**`Invites::Verifications`** — wraps `session[:verified_invites]`. `verified?(league_season)` and `mark!(league_season)` replace the two controller-private helpers that poked at the session directly. Defensive read against non-Hash session values; `||=` write to match the historical behavior.

**`Invites::ClaimSeat`** — atomic seat-claim primitive. Stamps `joined_at`, records the user, adds the seat's claim token to the visitor's cookie, kicks `Drafts::StartIfReady`. Both the manual `#claim` action and the auto-claim-lone-seat path go through it now, so the seat-claim invariant lives in one place.

**`Invites::Claim`** — orchestrates a code submission end-to-end: verify, mark verified, and — when the visitor isn't already a participant and there's exactly one open seat — auto-claim it via `ClaimSeat`. Returns a `Result` value object so callers branch cleanly:

\`\`\`ruby
result = Invites::Claim.call(league_season:, code:, user:, current_participant:, ...)
return redirect_after_claim(result) if result.verified?
flash.now[:alert] = "That invite code didn't match."
\`\`\`

### Controller after this

`#show` and `#verify_invite` now share an `attempt_invite` + `redirect_after_claim` pair instead of duplicating the verify-then-maybe-claim ladder. `#claim` becomes a thin wrapper around `Invites::ClaimSeat`. The leftover view-flag plumbing (`invite_verified:` on `Views::Leagues::Show`) calls `invite_verifications.verified?` directly.

Net: `leagues_controller.rb` -49 / +25. The three new files pick up the moved logic with comments explaining the contracts.

## Test plan

- [x] Full RSpec suite green (310 examples, 0 failures) — covers `claim_spec`, `league_invite_spec`, `leagues_spec`, `leagues_show_breakdown_spec`, `live_draft_spec`, `account_linking_spec`
- [x] StandardRB clean on touched files
- [x] Manual: create a league as owner; in a private window visit `/leagues/:id?invite=CODE` — confirm auto-claim fires and you land with the welcome flash
- [ ] Manual: visit a league without the invite code and try to claim a seat directly — confirm "Enter the league's invite code to claim a seat." flash
- [x] Manual: submit a bad invite code through the form — confirm "That invite code didn't match." flash and the league page renders
- [ ] Manual: with both seats already claimed, visit `?invite=CODE` — confirm verification still marks the session but no auto-claim happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)