### PR TITLE
refactor(views,params): ErrorAlert component; strong-params tidy

### DIFF
--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -41,10 +41,9 @@ class Admin::GamesController < Admin::BaseController
     @game = Game.find(params[:id])
   end
 
+  # Blank score fields ride through as empty strings; ActiveRecord's integer
+  # type-cast nils them on assignment, so no manual `.presence` is needed.
   def game_params
-    permitted = params.require(:game).permit(:status, :home_score, :away_score, :round, :week, :kickoff_at, :completed_at)
-    permitted[:home_score] = permitted[:home_score].presence
-    permitted[:away_score] = permitted[:away_score].presence
-    permitted
+    params.require(:game).permit(:status, :home_score, :away_score, :round, :week, :kickoff_at, :completed_at)
   end
 end

--- a/app/controllers/league_scoring_rules_controller.rb
+++ b/app/controllers/league_scoring_rules_controller.rb
@@ -22,9 +22,9 @@ class LeagueScoringRulesController < ApplicationController
 
   def update
     ApplicationRecord.transaction do
-      overrides_params.each do |id, attrs|
+      overrides_params.each do |id, points|
         override = @league_season.scoring_rule_overrides.find(id)
-        override.update!(points: attrs[:points])
+        override.update!(points: points)
       end
     end
     redirect_to edit_league_scoring_rules_path(@league), notice: "Scoring updated."
@@ -47,7 +47,12 @@ class LeagueScoringRulesController < ApplicationController
     @league_season.scoring_rule_overrides.includes(:scoring_rule).ordered.to_a
   end
 
+  # Form posts `overrides[<id>][points]=<value>`. Override IDs are dynamic
+  # keys, so each value is permitted individually rather than declaring one
+  # outer shape. Returns `{id_string => points_string}`.
   def overrides_params
-    params.require(:overrides).to_unsafe_h.transform_values { |v| v.slice(:points) }
+    params.require(:overrides).each_pair.to_h do |id, attrs|
+      [id, attrs.permit(:points)[:points]]
+    end
   end
 end

--- a/app/views/admin/games/edit.rb
+++ b/app/views/admin/games/edit.rb
@@ -24,13 +24,7 @@ class Views::Admin::Games::Edit < Views::Base
       )
       div(class: "card bg-base-100 shadow") do
         div(class: "card-body") do
-          if @game.errors.any?
-            div(class: "alert alert-error", role: "alert") do
-              ul(class: "list-disc list-inside") {
-                @game.errors.full_messages.each { |m| li { m } }
-              }
-            end
-          end
+          render Views::Components::ErrorAlert.new(records: @game)
 
           rounds = [Game::REGULAR_SEASON] +
             @game.season.sport.scoring_rules.where(kind: "playoff_appearance").ordered.pluck(:round_key)

--- a/app/views/admin/leagues/edit.rb
+++ b/app/views/admin/leagues/edit.rb
@@ -26,14 +26,7 @@ class Views::Admin::Leagues::Edit < Views::Base
         div(class: "card-body") do
           render_participants
 
-          if @league.errors.any? || @league_season&.errors&.any?
-            div(class: "alert alert-error", role: "alert") do
-              ul(class: "list-disc list-inside") {
-                @league.errors.full_messages.each { |m| li { m } }
-                @league_season&.errors&.full_messages&.each { |m| li { m } }
-              }
-            end
-          end
+          render Views::Components::ErrorAlert.new(records: [@league, @league_season])
 
           form_with(url: admin_league_path(@league), method: :patch, class: "space-y-3 mt-3") do |f|
             fieldset(class: "fieldset border border-base-300 rounded-lg p-4 space-y-3") do

--- a/app/views/admin/seasons/form.rb
+++ b/app/views/admin/seasons/form.rb
@@ -14,13 +14,7 @@ class Views::Admin::Seasons::Form < Views::Base
   end
 
   def view_template
-    if @season.errors.any?
-      div(class: "alert alert-error", role: "alert") do
-        ul(class: "list-disc list-inside") {
-          @season.errors.full_messages.each { |m| li { m } }
-        }
-      end
-    end
+    render Views::Components::ErrorAlert.new(records: @season)
 
     form_with(model: @season, url: @url, method: @method, scope: :season, class: "space-y-3") do |f|
       select_row(f, :sport_id, "Sport", @sports, required: true)

--- a/app/views/admin/teams/edit.rb
+++ b/app/views/admin/teams/edit.rb
@@ -16,13 +16,7 @@ class Views::Admin::Teams::Edit < Views::Base
       render Views::Components::Admin::PageHeader.new(title: "Edit #{@team.name}")
       div(class: "card bg-base-100 shadow") do
         div(class: "card-body") do
-          if @team.errors.any?
-            div(class: "alert alert-error", role: "alert") do
-              ul(class: "list-disc list-inside") {
-                @team.errors.full_messages.each { |m| li { m } }
-              }
-            end
-          end
+          render Views::Components::ErrorAlert.new(records: @team)
 
           form_with(model: @team, url: admin_team_path(@team), method: :patch, class: "space-y-3") do |f|
             text_field_row(f, :name, "Name", required: true)

--- a/app/views/admin/users/edit.rb
+++ b/app/views/admin/users/edit.rb
@@ -21,13 +21,7 @@ class Views::Admin::Users::Edit < Views::Base
 
       div(class: "card bg-base-100 shadow") do
         div(class: "card-body") do
-          if @user.errors.any?
-            div(class: "alert alert-error", role: "alert") do
-              ul(class: "list-disc list-inside") do
-                @user.errors.full_messages.each { |m| li { m } }
-              end
-            end
-          end
+          render Views::Components::ErrorAlert.new(records: @user)
 
           form_with(url: admin_user_path(@user), method: :patch, scope: :user, class: "space-y-3") do |f|
             div(class: "space-y-1") do

--- a/app/views/components/error_alert.rb
+++ b/app/views/components/error_alert.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Renders model validation errors (or any pre-built message list) as a
+# daisyUI `alert-error` block with a disc-bulleted list.
+#
+# Pass `messages:` directly, or `records:` to merge `errors.full_messages`
+# from one or more ActiveModel-ish objects (nils are skipped).
+#
+# Renders nothing if the message list is empty, so callers don't need to
+# guard with `errors.any?` themselves.
+class Views::Components::ErrorAlert < Views::Base
+  def initialize(messages: nil, records: nil, class_name: nil)
+    @messages = build_messages(messages, records)
+    @class_name = class_name
+  end
+
+  def view_template
+    return if @messages.empty?
+    div(class: alert_classes, role: "alert") do
+      ul(class: "list-disc list-inside") do
+        @messages.each { |msg| li { msg } }
+      end
+    end
+  end
+
+  private
+
+  def build_messages(messages, records)
+    return Array(messages) if messages
+    Array(records).flat_map { |r| r&.errors&.full_messages || [] }
+  end
+
+  def alert_classes
+    ["alert alert-error", @class_name].compact.join(" ")
+  end
+end

--- a/app/views/drafts/edit.rb
+++ b/app/views/drafts/edit.rb
@@ -213,11 +213,6 @@ class Views::Drafts::Edit < Views::Base
   end
 
   def render_errors
-    return unless @league_season&.errors&.any?
-    div(class: "alert alert-error mt-3", role: "alert") do
-      ul(class: "list-disc list-inside") do
-        @league_season.errors.full_messages.each { |msg| li { msg } }
-      end
-    end
+    render Views::Components::ErrorAlert.new(records: @league_season, class_name: "mt-3")
   end
 end

--- a/app/views/leagues/edit.rb
+++ b/app/views/leagues/edit.rb
@@ -95,13 +95,10 @@ class Views::Leagues::Edit < Views::Base
   end
 
   def render_errors
-    return unless @league.errors.any? || @league_season&.errors&.any?
-    div(class: "alert alert-error mt-3", role: "alert") do
-      ul(class: "list-disc list-inside") do
-        @league.errors.full_messages.each { |msg| li { msg } }
-        @league_season&.errors&.full_messages&.each { |msg| li { msg } }
-      end
-    end
+    render Views::Components::ErrorAlert.new(
+      records: [@league, @league_season],
+      class_name: "mt-3"
+    )
   end
 
   def history_hint

--- a/app/views/leagues/form.rb
+++ b/app/views/leagues/form.rb
@@ -96,10 +96,6 @@ class Views::Leagues::Form < Views::Base
   end
 
   def render_errors
-    div(class: "alert alert-error mb-4", role: "alert") do
-      ul(class: "list-disc list-inside") do
-        @errors.each { |msg| li { msg } }
-      end
-    end
+    render Views::Components::ErrorAlert.new(messages: @errors, class_name: "mb-4")
   end
 end

--- a/app/views/registrations/new.rb
+++ b/app/views/registrations/new.rb
@@ -51,10 +51,6 @@ class Views::Registrations::New < Views::Base
   end
 
   def render_errors
-    div(class: "alert alert-error mt-3", role: "alert") do
-      ul(class: "list-disc list-inside") do
-        @user.errors.full_messages.each { |msg| li { msg } }
-      end
-    end
+    render Views::Components::ErrorAlert.new(records: @user, class_name: "mt-3")
   end
 end


### PR DESCRIPTION
## Summary

Tier 5 + 6 of the architecture cleanup — the small finishing pass.

### `Views::Components::ErrorAlert`

The one extraction the Phlex audit flagged: every model-edit view re-implemented the `div alert alert-error` + `ul list-disc list-inside` + each-loop block. Some used `do/end`, some `{ }`, some bracketed margins (`mt-3`, `mb-4`), one combined errors from two records. A small Phlex component sweeps that up:

\`\`\`ruby
render Views::Components::ErrorAlert.new(records: @user)
render Views::Components::ErrorAlert.new(records: [@league, @league_season], class_name: "mt-3")
render Views::Components::ErrorAlert.new(messages: @errors, class_name: "mb-4")  # for pre-built lists
\`\`\`

It accepts either `messages:` (a pre-built array) or `records:` (one or many ActiveModel-ish objects whose `errors.full_messages` get merged, nils skipped). Renders nothing when the list is empty, so callers stop guarding with `errors.any?` themselves.

**Adopters (9 views):** `registrations/new`, `leagues/{form,edit}`, `drafts/edit`, `admin/{games,seasons,teams,users,leagues}/{edit,form}`. The league + admin/league edits keep their two-record behavior by passing `[@league, @league_season]`.

**Intentionally left inline:** `league_scoring_rules/edit` — it does bespoke per-row formatting (`"#{rule.label}: #{msg}"`) that doesn't fit the generic component.

### Strong-params tidy

- `Admin::GamesController#game_params` drops the manual `presence` blank-clearing on `home_score` / `away_score`. ActiveRecord's integer type-cast nils empty strings on assignment, so the loop was a no-op for nullable integer columns.
- `LeagueScoringRulesController#overrides_params` replaces `to_unsafe_h.transform_values { _1.slice(:points) }` with a proper `permit(:points)` per dynamic-keyed entry. Returns `{id_string => points_string}` so the update loop iterates `(id, points)` instead of `(id, attrs)`.

Net: 11 files, +23 / -66.

## Test plan

- [x] Full RSpec suite green (310 examples, 0 failures)
- [x] StandardRB clean on touched files
- [ ] Manual: visit each edit form (leagues, drafts, league scoring rules, admin/games, admin/teams, admin/seasons, admin/users, admin/leagues) and trigger a validation error — confirm the alert renders identically to before
- [ ] Manual: edit a game, leave score fields blank — confirm scores save as nil (not empty string)
- [ ] Manual: edit league scoring rules with a non-integer point value — confirm validation error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)